### PR TITLE
Deprecated fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ node_modules
 # Build output
 lib
 !src/lib
+
+# Mac OSX
+.DS_Store

--- a/src/SmsApiClient.js
+++ b/src/SmsApiClient.js
@@ -4,7 +4,7 @@ import Promise from 'bluebird';
 import { ArgumentError, ApiError, ValidationError } from './errors';
 
 export default class SmsApiClient {
-  constructor({ baseUrl = 'https://www.spryng.be', username, password }) {
+  constructor({ baseUrl = 'https://api.spryngsms.com/api/', username, password }) {
     if (username === null || username === undefined) {
       throw new ArgumentError('Must provide a username for the SMS Gateway API');
     }


### PR DESCRIPTION
Replace the old base url (https://www.spryng.be) with the new one (https://api.spryngsms.com/api/) and add Mac OSX file (.DS_Store) to .gitignore.