### PR TITLE
Replace deprecated URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ node_modules
 # Build output
 lib
 !src/lib
+
+# Mac OSX
+.DS_Store

--- a/src/SmsApiClient.js
+++ b/src/SmsApiClient.js
@@ -4,7 +4,7 @@ import Promise from 'bluebird';
 import { ArgumentError, ApiError, ValidationError } from './errors';
 
 export default class SmsApiClient {
-  constructor({ baseUrl = 'https://api.spryngsms.com/api/', username, password }) {
+  constructor({ baseUrl = 'https://api.spryngsms.com/api', username, password }) {
     if (username === null || username === undefined) {
       throw new ArgumentError('Must provide a username for the SMS Gateway API');
     }

--- a/src/SmsApiClient.js
+++ b/src/SmsApiClient.js
@@ -4,7 +4,7 @@ import Promise from 'bluebird';
 import { ArgumentError, ApiError, ValidationError } from './errors';
 
 export default class SmsApiClient {
-  constructor({ baseUrl = 'https://www.spryng.be', username, password }) {
+  constructor({ baseUrl = 'https://api.spryngsms.com/api/', username, password }) {
     if (username === null || username === undefined) {
       throw new ArgumentError('Must provide a username for the SMS Gateway API');
     }


### PR DESCRIPTION
Had contact with Spryng and they told me the .be URL is deprecated. See this email from a Spryng employee:

"De library die u gebruikt is niet officieel en gebruikt een deprecated API endpoint. Als u kijkt in de source code van SmsApiClient.js ziet u dat de baseUrl https://www.spryng.be is. Dit moet https://api.spryngsms.com/api/ zijn."

Translated from Dutch:
Your using an unofficial library with a deprecated API endpoint. It should be https://api.spryngsms.com/api/ instead of https://www.spryng.be/.
